### PR TITLE
[new pattern] chain of responsibility

### DIFF
--- a/specs/unit/patterns/behavioral/chainOfResponsibility.spec.js
+++ b/specs/unit/patterns/behavioral/chainOfResponsibility.spec.js
@@ -4,6 +4,8 @@ describe('chain of responsibility', function() {
   var arraySpy;
   var functionSpy;
   var constructorSpy;
+  var shouldNotRunSpy;
+  var defaultSpy;
   var Pattern;
   var patternImplementation;
   var chain;
@@ -11,7 +13,9 @@ describe('chain of responsibility', function() {
     constructorSpy = jasmine.createSpy("constructor");
     arraySpy = jasmine.createSpy("array");
     functionSpy = jasmine.createSpy("object");
-    Pattern = buildPattern({
+    shouldNotRunSpy = jasmine.createSpy("shouldNotRun");
+    defaultSpy = jasmine.createSpy("default");
+    Pattern = chainOfResponsibility({
       constructor: _ => {
         constructorSpy();
       },
@@ -21,13 +25,11 @@ describe('chain of responsibility', function() {
     });
     patternImplementation = Pattern.build();
     chain = new patternImplementation()
-    .add((next, t) => {
-      return "default";
-    })
+    .add(defaultSpy)
     .add((next, t) => {
       if(t instanceof Array) {
         arraySpy();
-        return t;
+        return "array";
       }
       next();
     })
@@ -41,7 +43,14 @@ describe('chain of responsibility', function() {
     .add((next, t) => {
       if(t instanceof Function) {
         functionSpy();
-        return t;
+        return "function";
+      }
+      next();
+    })
+    .add((next, t) => {
+      if(t === "continue") {
+        next();
+        return "shouldNotReturnThis";
       }
       next();
     });
@@ -51,23 +60,34 @@ describe('chain of responsibility', function() {
     expect(constructorSpy).toHaveBeenCalled();
   });
   it('should chain callbacks', function() {
-    expect(chain.run()).toEqual("default");
-
+    chain.run();
+    expect(chain.run([])).toEqual("array");
+    expect(chain.run(_ => {})).toEqual("function");
+    expect(defaultSpy).toHaveBeenCalled();
+    expect(functionSpy).toHaveBeenCalled();
+    expect(arraySpy).toHaveBeenCalled();
   });
   it('can shadow callbacks', function() {
-    
+    expect(chain.run(_ => {})).not.toEqual("shouldNotRun");
+    expect(shouldNotRunSpy).not.toHaveBeenCalled();
   });
   it('can continue the chain even if callback was used', function() {
-    
+    var t = chain.run("continue")
+    expect(t).not.toEqual("shouldNotReturnThis");
+    expect(defaultSpy).toHaveBeenCalled();
   });
-  it('should run regardless of the context', function() {
-    
+  it('should run regardless of the context allowing to pass as callback', function(done) {
+    setTimeout(chain.run);
+    setTimeout(_ => {
+      expect(defaultSpy).toHaveBeenCalled();
+      done();
+    }, 30);
   });
   it('should count the callbacks', function() {
-    
+    expect(chain.count()).toEqual(5);
   });
   it('should find callbacks', function() {
-    
+    expect(chain.contains(defaultSpy)).toBeTruthy();
+    expect(chain.contains(_ => {})).toBeFalsy();
   });
-
 });

--- a/src/patterns/behavioral/chainOfResponsibility.js
+++ b/src/patterns/behavioral/chainOfResponsibility.js
@@ -29,7 +29,7 @@ export default buildPattern(options => {
     },
 
     count() {
-      return this.chain.length();
+      return this.chain.length;
     },
 
     contains(fn) {
@@ -38,79 +38,3 @@ export default buildPattern(options => {
   });
   return ChainOfResponsibility;
 });
-
-// class ChainOfResponsibility {
-//   constructor(heuristic) {
-//     this.heuristic = heuristic;
-//     this.chain = [];
-//   }
-//   overload(link) {
-//     this.chain.unshift(link);
-//   }
-//   find(args) {
-//     var argsLength = args.length;
-//     for(let i = 0; i < argsLength; i++) {
-//       let link = this.chain[i];
-//       if(link.heuristics.forEach) {
-//         let found = true;
-//         let heuristicsLength = link.heuristics.length;
-//         if(heuristicsLength !== argsLength) { continue; }
-//         for(let j = 0; j < heuristicsLength; j++) {
-//           if(!link.heuristics[j](args[j])) {
-//             found = false;
-//           }
-//         }
-//         if(found) { return link.callback; }
-//       } else {
-//         if(link.heuristics.apply(link.callback, args)) {
-//           return link.callback;
-//         }
-//       }
-//     }
-//     return () => { throw new Error("chained callback not found"); }
-//   }
-// }
-
-// /**
-//  * @return {Function} chain
-//  */
-// export default extend(() => {
-//   var cOR = new ChainOfResponsibility();
-//   return extend((...args) => {
-//     cOR.find(args).apply(this, args);
-//   }, {
-//     /**
-//      * @method
-//      *
-//      * @param {Function} callback will be added to the top of the chain.
-//      * @param {[Array, Function]} heuristics array of functions per argument
-//      *                            or single function that will receive the 
-//      *                            arguments passed to the original function.
-//      */
-//     addLink(callback, heuristics = []) {
-//       cOR.overload({ callback, heuristics });
-//       return this;
-//     }
-//   });
-// }, {
-//   heuristics: {
-//     isTypeOf(type) {
-//       return logicalFunction((arg) => {
-//         return typeof arg === type;
-//       });
-//     },
-//     isInstanceOf(constructor) {
-//       return logicalFunction((arg) => {
-//         return arg instanceof constructor;
-//       });
-//     },
-//     implementsInterface(methodsArray) {
-//       return logicalFunction((instance) => {
-//         for(let i = 0; i < methodsArray.length; i++) {
-//           if(!(methodsArray[i] in instance)) { return false; }
-//         }
-//         return true;
-//       });
-//     }
-//   }
-// });


### PR DESCRIPTION
not convinced with the functionality

I'm still not convinced if it should be an object type of option passed:

```
    chain
    .addLink(isObjectSpy, {
      types: ["object"],
      instances: [Object]
    });
```

or a parameter type:

```
    chain
    .addLink(isObjectSpy, [
      isTypeOf("object").and(isInstanceOf(Object))
    ]);
```
