### PR TITLE
[new pattern] mvw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+- Introducing MVW pattern
+
 ### Fixed
 ### Changed
+- Modified babel presets and plugins
 
 ## [v1.0.2](https://github.com/pgarciacamou/go-patterns/releases/tag/v1.0.2) - 2017-04-23
 ### Added

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ JavaScript Design-Patterns Builder
 
 ### Background
 
-go-patterns is a tool that builds **design** patterns _on the fly_. The original idea was to create a library that could allow an easy access to inherit/inject patterns into the code without having to worry much about the actual implementation. Due to the complexity of a lot of patterns and some restrictions on ES6, it mutated into an API built around the builder pattern, which dynamically creates patterns using JavaScript.
+go-patterns is a tool that builds design patterns _on the **go**_. The original idea was to create a library that could allow an easy access to inherit/inject patterns into the code without having to worry much about the actual implementation. Due to the complexity of a lot of patterns and some restrictions on ES6, it mutated into an API built around the builder pattern, which dynamically creates patterns using JavaScript.
 
-The overhead, file size, and footprint of this library is intended to be very small, thus most of the patterns are simplified/abstracted to a heavy extent. Abstracting the patterns was crucial as it increased the flexibility of the library, allowed to wrap patterns on top of other patterns, and made patterns compatible with the library's pre-designed API.
+The overhead, file size, and footprint of this library is intended to be very small (currently <15KB [<4KB when gzipped]), thus most of the patterns are simplified/abstracted to a heavy extent. Abstracting the patterns was crucial as it increased the flexibility of the library, allowed to wrap patterns on top of other patterns, and made patterns compatible with the library's pre-designed API.
 
-In order to get the patterns working correctly I was thoroughly guided by the book [Essential JS Design Patterns](https://addyosmani.com/resources/essentialjsdesignpatterns/book/). There are lots of more complex patterns in this book (e.g. MVVM, MVP, ...) that are missing from this library. Some patterns I'm working on, some I don't really have time to implement, and some others are very hard to abstract to make it compatible with the API. Don't worry, I plan to update it as I can and, as always, PRs are welcomed.
+In order to get the patterns working correctly, I followed —as much as possible— the patterns' implementations from the [Essential JS Design Patterns](https://addyosmani.com/resources/essentialjsdesignpatterns/book/) book. There are still a lot more patterns in this book that are missing from this library, some patterns I'm working on, some I don't really have time to implement, and some others are very hard to abstract to make it compatible with the API, e.g. I just added the MVW pattern which took a while to abstract to something flexible and usable that didn't consume a lot of computer power.
 
 ### When To Use
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ In order to get the patterns working correctly, I followed —as much as possibl
 
 ### When To Use
 
-I recommend using this library to quickly build code around design patterns but only as proof of concept (POC). Once the POC is finalized, I strongly suggest moving away from this library and add more robust pattern implementations, as they could be optimized/improved based on your project's requirements. Also, keep in mind that this library uses some techniques (e.g. dynamic inheritance) that are, most likely, considered bad practices as they could have side effects but, thanks to my experience working with JavaScript, I was able to work around them.
+I recommend using this library to quickly build code around design patterns but only as proof of concept (POC). Once the POC is finalized, I strongly suggest moving away from this library and add more robust pattern implementations, as they could be optimized/improved based on your project's requirements. Also, keep in mind that this library uses some advanced techniques (e.g. dynamic inheritance) that are not part of JavaScript and that are, most likely, considered bad practices as they could have side effects. Rest assure, I have years of experience working with JavaScript and knowing about the side effects I was able to work around them.
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ NOTE: if you really need to see how to use a specific pattern, please check the 
 
 A simple example is the singleton, which the idea behind it is that you can only create a single instance from a class.
 
+The simplest way to create a singleton is:
+
+```js
+import patterns from 'go-patterns';
+
+let Singleton = patterns.singleton().build();
+
+console.log(new Singleton() === new Singleton()) // true
+```
+
+A more verbose approach is:
+
 ```js
 import patterns from 'go-patterns';
 
@@ -53,7 +65,7 @@ let options = {
   statics: {}  // will be attached to the constructor
 };
 
-// Note: the options object is completely optional.
+// Note: the options object is completely optional (as seen in the example above).
 var Singleton = patterns.singleton(options).build();
 var singleton1 = new Singleton();
 var singleton2 = new Singleton();

--- a/README.md
+++ b/README.md
@@ -1,37 +1,10 @@
 # go-patterns
 JavaScript Design-Patterns Builder
 
-### Background
-
-go-patterns is a tool that builds design patterns _on the **go**_. The original idea was to create a library that could allow an easy access to inherit/inject patterns into the code without having to worry much about the actual implementation. Due to the complexity of a lot of patterns and some restrictions on ES6, it mutated into an API built around the builder pattern, which dynamically creates patterns using JavaScript.
-
-The overhead, file size, and footprint of this library is intended to be very small (currently <15KB [<4KB when gzipped]), thus most of the patterns are simplified/abstracted to a heavy extent. Abstracting the patterns was crucial as it increased the flexibility of the library, allowed to wrap patterns on top of other patterns, and made patterns compatible with the library's pre-designed API.
-
-In order to get the patterns working correctly, I followed —as much as possible— the patterns' implementations from the [Essential JS Design Patterns](https://addyosmani.com/resources/essentialjsdesignpatterns/book/) book. There are still a lot more patterns in this book that are missing from this library, some patterns I'm working on, some I don't really have time to implement, and some others are very hard to abstract to make it compatible with the API, e.g. I just added the MVW pattern which took a while to abstract to something flexible and usable that didn't consume a lot of computer power.
-
-### When To Use
-
-I recommend using this library to quickly build code around design patterns but only as proof of concept (POC). Once the POC is finalized, I strongly suggest moving away from this library and add more robust pattern implementations, as they could be optimized/improved based on your project's requirements. Also, keep in mind that this library uses some advanced techniques (e.g. dynamic inheritance) that are not part of JavaScript and that are, most likely, considered bad practices as they could have side effects. Rest assure, I have years of experience working with JavaScript and knowing about the side effects I was able to work around them.
-
 ### Installation
 
 1. `npm install --save go-patterns` on your project
 2. `import patterns from 'go-patterns';`
-
-### Development
-
-1. fork/clone repo
-2. install dependencies `npm install`
-3. run unit test suites `npm run test`
-
-### Deployment (Publish && Release)
-
-1. Login to NPM: `npm login`
-2. Increase library version: `npm version [major|minor|patch]`
-3. Upload new tag created on step 2: `git push origin <new tag>`
-4. Create distribution files `npm run dist`
-5. Create release in GitHub (attach dist/* files created in step 4)
-6. Publish: `npm publish`
 
 ### How To Use
 
@@ -138,3 +111,30 @@ console.log(B.genNumber()); // unrepeated random number from 0 to 100
 ```
 
 NOTE: Don't forget to add the respective unit tests for quality purposes.
+
+### Development
+
+1. fork/clone repo
+2. install dependencies `npm install`
+3. run unit test suites `npm run test`
+
+### Deployment (Publish && Release)
+
+1. Login to NPM: `npm login`
+2. Increase library version: `npm version [major|minor|patch]`
+3. Upload new tag created on step 2: `git push origin <new tag>`
+4. Create distribution files `npm run dist`
+5. Create release in GitHub (attach dist/* files created in step 4)
+6. Publish: `npm publish`
+
+### When To Use
+
+I recommend using this library to quickly build code around design patterns but only as proof of concept (POC). Once the POC is finalized, I strongly suggest moving away from this library and add more robust pattern implementations, as they could be optimized/improved based on your project's requirements. Also, keep in mind that this library uses some advanced techniques (e.g. dynamic inheritance) that are not part of JavaScript and that are, most likely, considered bad practices as they could have side effects. Rest assure, I have years of experience working with JavaScript and knowing about the side effects I was able to work around them.
+
+### Background
+
+go-patterns is a tool that builds design patterns _on the **go**_. The original idea was to create a library that could allow an easy access to inherit/inject patterns into the code without having to worry much about the actual implementation. Due to the complexity of a lot of patterns and some restrictions on ES6, it mutated into an API built around the builder pattern, which dynamically creates patterns using JavaScript.
+
+The overhead, file size, and footprint of this library is intended to be very small (currently <15KB [<4KB when gzipped]), thus most of the patterns are simplified/abstracted to a heavy extent. Abstracting the patterns was crucial as it increased the flexibility of the library, allowed to wrap patterns on top of other patterns, and made patterns compatible with the library's pre-designed API.
+
+In order to get the patterns working correctly, I followed —as much as possible— the patterns' implementations from the [Essential JS Design Patterns](https://addyosmani.com/resources/essentialjsdesignpatterns/book/) book. There are still a lot more patterns in this book that are missing from this library, some patterns I'm working on, some I don't really have time to implement, and some others are very hard to abstract to make it compatible with the API, e.g. I just added the MVW pattern which took a while to abstract to something flexible and usable that didn't consume a lot of computer power.

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -32,7 +32,10 @@ module.exports = function(config) {
     browserify: {
       debug: true,
       transform: [ 
-        ['babelify', {presets: [ "es2015" ]}] 
+        ['babelify', {
+          presets: [ "es2015", "es2016", "es2017" ],
+          plugins: [ "transform-object-rest-spread" ]
+        }] 
       ],
       extensions: [ '.js' ]
     },

--- a/package.json
+++ b/package.json
@@ -36,7 +36,10 @@
   "homepage": "https://github.com/pgarciacamou/go-patterns#readme",
   "devDependencies": {
     "babel-eslint": "^7.2.1",
+    "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-es2015": "^6.9.0",
+    "babel-preset-es2016": "^6.24.1",
+    "babel-preset-es2017": "^6.24.1",
     "babelify": "^7.3.0",
     "browserify": "^13.0.1",
     "eslint": "^3.18.0",

--- a/specs/unit/index.spec.js
+++ b/specs/unit/index.spec.js
@@ -3,7 +3,7 @@ import patterns from '../../index.js';
 
 describe('patterns API', function() {
   it('should describe an API', function() {
-    expect(Object.keys(patterns).length).toEqual(8);
+    expect(Object.keys(patterns).length).toEqual(9);
   });
   it('should contain patterns', function() {
     expect(patterns.singleton).toBeDefined();
@@ -14,5 +14,6 @@ describe('patterns API', function() {
     expect(patterns.command).toBeDefined();
     expect(patterns.memento).toBeDefined();
     expect(patterns.flyweight).toBeDefined();
+    expect(patterns.mvw).toBeDefined();
   });
 });

--- a/specs/unit/patterns/architectural/mvw.spec.js
+++ b/specs/unit/patterns/architectural/mvw.spec.js
@@ -1,0 +1,209 @@
+/* globals expect, beforeEach, it, describe, spyOn, jasmine */
+import mvwBuilder from '../../../../src/patterns/architectural/mvw.js';
+
+function dispatchEvent(element, eventName, eventData) {
+  var ev = document.createEvent("Event");
+  ev.data = eventData;
+  ev.initEvent(eventName, true, true);
+  element.dispatchEvent(ev);
+}
+
+describe('mvw', function() {
+  let MVW;
+  let mvw;
+  let somePropOptions;
+  let shouldModelUpdateSpy;
+  let updateValueCallback;
+  let fakeUpdateView;
+
+  beforeEach(function() {
+    MVW = mvwBuilder().build();
+    mvw = new MVW();
+  });
+  it('should allow empty options', function() {
+    let emptyOptions = undefined;
+    expect(() => new MVW(emptyOptions)).not.toThrow();
+  });
+  it('should access the mvw instance withing the methods', function() {
+    mvw.add('test', {
+      default: 1,
+      modelDidUpdate() {
+        expect(this).toEqual(mvw);
+      }
+    })
+  });
+
+  describe('full options', function() {
+    beforeEach(function() {
+      shouldModelUpdateSpy = jasmine.createSpy('shouldModelUpdateSpy');
+
+      somePropOptions = {
+        defaultValue: 1,
+        shouldModelUpdate(newValue, oldValue) { return true },
+        modelWillUpdate(newValue, oldValue) {},
+        modelDidUpdate(newValue) {},
+        handleViewUpdate(updateValue) {
+          updateValueCallback = updateValue;
+          fakeUpdateView = value => updateValue(value);
+        }
+      };
+
+      spyOn(somePropOptions, 'shouldModelUpdate').and.callThrough();
+      spyOn(somePropOptions, 'modelWillUpdate');
+      spyOn(somePropOptions, 'modelDidUpdate');
+      spyOn(somePropOptions, 'handleViewUpdate').and.callThrough();
+
+      mvw.add('someProp', somePropOptions);
+    });
+
+    it('should have add a default value', function() {
+      expect(mvw.model.someProp.value).toEqual(1);
+    });
+    it('should have run shouldModelUpdate method once', function() {
+      expect(somePropOptions.shouldModelUpdate).toHaveBeenCalledTimes(1);
+      expect(somePropOptions.shouldModelUpdate).toHaveBeenCalledWith(1, undefined);
+    });
+    it('should have run modelWillUpdate method once', function() {
+      expect(somePropOptions.modelWillUpdate).toHaveBeenCalledTimes(1);
+      expect(somePropOptions.modelWillUpdate).toHaveBeenCalledWith(1, undefined);
+    });
+    it('should have run modelDidUpdate method once', function() {
+      expect(somePropOptions.modelDidUpdate).toHaveBeenCalledWith(1);
+      expect(somePropOptions.modelDidUpdate).toHaveBeenCalledWith(1);
+    });
+    it('should have run handleViewUpdate', function() {
+      expect(somePropOptions.handleViewUpdate).toHaveBeenCalledTimes(1);
+      expect(somePropOptions.handleViewUpdate).toHaveBeenCalledWith(updateValueCallback);
+    });
+    it('should not update value', function() {
+      mvw.model.someProp.value = 1;
+      expect(somePropOptions.shouldModelUpdate).toHaveBeenCalledTimes(1);
+      expect(somePropOptions.modelWillUpdate).toHaveBeenCalledTimes(1);
+      expect(somePropOptions.modelDidUpdate).toHaveBeenCalledTimes(1);
+    });
+    it('should update value', function() {
+      mvw.model.someProp.value = 2;
+      expect(somePropOptions.modelWillUpdate).toHaveBeenCalledTimes(2);
+      expect(somePropOptions.modelWillUpdate).toHaveBeenCalledWith(2, 1);
+      expect(somePropOptions.modelDidUpdate).toHaveBeenCalledTimes(2);
+      expect(somePropOptions.modelDidUpdate).toHaveBeenCalledWith(2);
+    });
+    it('should update value on view update', function() {
+      fakeUpdateView(3);
+      expect(mvw.model.someProp.value).toEqual(3);
+    });
+  });
+  describe('no default value', function() {
+    beforeEach(function() {
+      shouldModelUpdateSpy = jasmine.createSpy('shouldModelUpdateSpy');
+
+      somePropOptions = {
+        shouldModelUpdate(newValue, oldValue) { return true },
+        modelWillUpdate(newValue, oldValue) {},
+        modelDidUpdate(newValue) {},
+        handleViewUpdate(updateValue) {}
+      };
+
+      spyOn(somePropOptions, 'shouldModelUpdate').and.callThrough();
+      spyOn(somePropOptions, 'modelWillUpdate');
+      spyOn(somePropOptions, 'modelDidUpdate');
+      spyOn(somePropOptions, 'handleViewUpdate');
+
+      mvw.add('someProp', somePropOptions);
+    });
+
+    it('should not have a default value', function() {
+      expect(mvw.model.someProp.value).toBeUndefined();
+    });
+    it('should not have updated model', function() {
+      expect(somePropOptions.shouldModelUpdate).not.toHaveBeenCalled();
+      expect(somePropOptions.modelWillUpdate).not.toHaveBeenCalled();
+      expect(somePropOptions.modelDidUpdate).not.toHaveBeenCalled();
+    });
+    it('should still call handle view update', function() {
+      expect(somePropOptions.handleViewUpdate).toHaveBeenCalled();
+    });
+  });
+  describe('empty options', function() {
+    let emptyOptions;
+    beforeEach(function() {
+      mvw.add('someProp', emptyOptions);
+    });
+    it('should allow to add methods after', function() {
+      mvw.model.someProp.shouldModelUpdate = jasmine.createSpy('shouldModelUpdate').and.returnValue(true);
+      mvw.model.someProp.modelWillUpdate = jasmine.createSpy('modelWillUpdate');
+      mvw.model.someProp.modelDidUpdate = jasmine.createSpy('modelDidUpdate');
+      mvw.model.someProp.value = 1;
+      expect(mvw.model.someProp.shouldModelUpdate).toHaveBeenCalled();
+      expect(mvw.model.someProp.modelWillUpdate).toHaveBeenCalled();
+      expect(mvw.model.someProp.modelDidUpdate).toHaveBeenCalled();
+    });
+  });
+
+  describe('Advanced Level: DOM element updates', function() {
+    let afterValue;
+    let beforeValue;
+    beforeEach(function() {
+      afterValue = 2;
+      beforeValue = 1;
+
+      MVW = mvwBuilder({
+        constructor() {
+          this.elem = document.body;
+        }
+      }).build();
+      mvw = new MVW();
+      mvw.add('bodyState', {
+        defaultValue: 1,
+        shouldModelUpdate(newValue, oldValue) {
+          return !isNaN(newValue) && newValue > 0;
+        },
+        modelWillUpdate(newValue, oldValue) {
+          this.elem.classList.remove(`state-${oldValue}`);
+          this.elem.classList.add(`state-${newValue}`);
+        },
+        handleViewUpdate(updateValue) {
+          this.elem.addEventListener('mouseenter', () => updateValue(afterValue), false);
+          this.elem.addEventListener('mouseleave', () => updateValue(beforeValue), false);
+        }
+      });
+    });
+    it('should update value on mouseenter', function() {
+      dispatchEvent(document.body, 'mouseenter', {});
+      expect(mvw.model.bodyState.value).toEqual(afterValue);
+    });
+    it('should update value on mouseleave', function() {
+      dispatchEvent(document.body, 'mouseleave', {});
+      expect(mvw.model.bodyState.value).toEqual(beforeValue);
+    });
+  });
+  describe('Advanced Level: Input value updates', function() {
+    let modelWillUpdateSpy;
+    let input;
+    beforeEach(function() {
+      modelWillUpdateSpy = jasmine.createSpy('modelWillUpdateSpy');
+
+      MVW = mvwBuilder({
+        constructor() {
+          this.input = input = document.createElement('input');
+        }
+      }).build();
+      mvw = new MVW();
+      mvw.add('name', {
+        modelWillUpdate(newValue, oldValue) {
+          modelWillUpdateSpy(newValue, oldValue);
+          this.input.value = newValue;
+        },
+        handleViewUpdate(updateValue) {
+          this.input.addEventListener("input", e => updateValue(this.input.value), false);
+        }
+      });
+    });
+    it('should not have circular updates (infinite loops)', function() {
+      input.value = 'update';
+      dispatchEvent(input, 'input', {});
+      expect(modelWillUpdateSpy).toHaveBeenCalledTimes(1);
+      expect(modelWillUpdateSpy).toHaveBeenCalledWith('update', undefined);
+    });
+  });
+});

--- a/src/go-patterns.js
+++ b/src/go-patterns.js
@@ -6,6 +6,7 @@ import mediator from './patterns/behavioral/mediator.js';
 import command from './patterns/behavioral/command.js';
 import memento from './patterns/behavioral/memento.js';
 import flyweight from './patterns/structural/flyweight.js';
+import mvw from './patterns/architectural/mvw.js';
 
 var patterns = {
   singleton,
@@ -15,7 +16,8 @@ var patterns = {
   mediator,
   command,
   memento,
-  flyweight
+  flyweight,
+  mvw
 };
 
 export default patterns;

--- a/src/patterns/architectural/mvw.js
+++ b/src/patterns/architectural/mvw.js
@@ -1,0 +1,40 @@
+import extend from '../../helpers/extend.js';
+import createPatternBuilder from '../../helpers/createPatternBuilder.js';
+
+export default createPatternBuilder(options => {
+  function MVW(...args) {
+    this.flyweights = {};
+    this.model = {};
+    options.constructor.apply(this, args);
+  }
+  extend(MVW.prototype, {
+    add(prop, propOptions={}) {
+      let self = this;
+      let value;
+      
+      propOptions = this.model[prop] = {
+        shouldModelUpdate() { return true; },
+        modelWillUpdate() {},
+        modelDidUpdate() {},
+        handleViewUpdate() {},
+        ...propOptions
+      };
+      
+      Object.defineProperty(propOptions, 'value', {
+        set(newValue) {
+          if(value !== newValue && propOptions.shouldModelUpdate.call(self, newValue, value)) {
+            propOptions.modelWillUpdate.call(self, newValue, value);
+            propOptions.modelDidUpdate.call(self, value = newValue);
+          }
+        },
+        get() {
+          return value;
+        }
+      });
+      
+      propOptions.handleViewUpdate.call(self, value => propOptions.value = value);
+      propOptions.value = propOptions.defaultValue;
+    }
+  });
+  return MVW;
+});

--- a/src/patterns/architectural/mvw.js
+++ b/src/patterns/architectural/mvw.js
@@ -3,7 +3,6 @@ import createPatternBuilder from '../../helpers/createPatternBuilder.js';
 
 export default createPatternBuilder(options => {
   function MVW(...args) {
-    this.flyweights = {};
     this.model = {};
     options.constructor.apply(this, args);
   }


### PR DESCRIPTION
#This PR replaces #17 and introduces an abstraction of MVW to the library that it's functionally similar to the other patterns.

1. The pattern naming conventions are mainly based on the naming conventions of React, and so far it does not implement observables, it updates the model through proxies (getters and setters).
2. So far, it does not handle object updates on its own (multi-level "observations"), which was what made the other PR so complex.

- [x] ~~increase minor version of library to v1.1.0~~
- [x] update README.md (if possible, remove "missing MVW", unbold design from "go-patterns is a tool that builds **design** patterns on the fly", etc...)
- [x] update CHANGELOG.md
