### PR TITLE
[update] minor code changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Minor updates to code.
 ### Changed
+- Refactor `extend()` helper to use Object.assign by using babel plugin transform-object-assign.
 
 ## [v3.0.0](https://github.com/pgarciacamou/go-patterns/releases/tag/v3.0.0) - 2017-07-04
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 ### Fixed
+- Minor updates to code.
 ### Changed
 
 ## [v3.0.0](https://github.com/pgarciacamou/go-patterns/releases/tag/v3.0.0) - 2017-07-04

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -33,7 +33,7 @@ module.exports = function(config) {
       transform: [ 
         ['babelify', {
           presets: [ "es2015", "es2016", "es2017" ],
-          plugins: [ "transform-object-rest-spread" ]
+          plugins: [ "transform-object-rest-spread", "transform-object-assign" ]
         }] 
       ],
       extensions: [ '.js' ]

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "babel-core": "^6.24.1",
     "babel-eslint": "^7.2.1",
     "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-transform-object-assign": "^6.22.0",
     "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-es2016": "^6.24.1",

--- a/src/helpers/createPatternBuilder.js
+++ b/src/helpers/createPatternBuilder.js
@@ -3,7 +3,7 @@ import extend from './extend.js';
 export default function createPatternBuilder(getPattern) {
   return function(options = {}) {
     options = extend({
-      constructor: () => {},
+      constructor: function() {},
       publics: {},
       statics: {}
     }, options);

--- a/src/helpers/extend.js
+++ b/src/helpers/extend.js
@@ -1,11 +1,3 @@
-export default (dest, ...srcs) => {
-  srcs.forEach((src) => {
-    for(var prop in src) {
-      if(src.hasOwnProperty(prop)) {
-        dest[prop] = src[prop];
-      }
-    }
-  });
-
-  return dest;
+export default (...objs) => {
+  return Object.assign(...objs);
 };


### PR DESCRIPTION
1. Babel transpiler seems to allow to use an arrow function as a constructor, but according to the libraries docs, it should not be this way. It makes sense to change this to what the documentation establishes.
2. Instead of creating an `extend()` helper method due to the lack of Object.assign, use babel plugin as babel is already a dev dependency of the project. It makes more sense to use something that is more broadly reviewed by the dev community.