### PR TITLE
move public props to outer most pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 ### Fixed
+- Move public props to prototype object of outer most pattern.
 ### Changed
 
 ## [v3.0.1](https://github.com/pgarciacamou/go-patterns/releases/tag/v3.0.1) - 2017-07-22

--- a/src/helpers/createPatternBuilder.js
+++ b/src/helpers/createPatternBuilder.js
@@ -1,29 +1,37 @@
 import extend from './extend.js';
 
-export default function createPatternBuilder(getPattern) {
-  return function(options = {}) {
+export default function createPatternBuilder(getConstructor) {
+  return (options = {}) => {
     options = extend({
+      // can't be an arrow function as it does not have a prototype
       constructor: function() {},
       publics: {},
       statics: {}
     }, options);
 
-    var __class = getPattern(options);
-    __class.prototype = extend(
+    const __constructor = getConstructor(options);
+
+    // half of the dynamic inheritance the other half goes on
+    // within the pattern's constructor itself
+    __constructor.prototype = extend(
       Object.create(options.constructor.prototype),
       { constructor: options.constructor },
-      __class.prototype,
-      options.publics
+      __constructor.prototype
     );
 
-    return {
-      constructor: __class,
-      publics: __class.prototype,
+    const builder = {
+      constructor: __constructor,
+      publics: options.publics,
       statics: options.statics,
       build() {
-        return extend(__class, options.statics);
+        // copy public options into outermost pattern
+        extend(__constructor.prototype, options.publics);
+
+        // extend constructor with static props
+        return extend(__constructor, options.statics);
       }
     };
 
+    return builder;
   };
 }


### PR DESCRIPTION
Fixes #46 

```js
var options = {
  publics: {
    one: 1
  }
};

var factoryBuilder = patterns.factory(options);
var singletonBuilder = patterns.singleton(factoryBuilder);
var Singleton = patterns.singleton(singletonBuilder).build();

console.log(Singleton.prototype.constructor.prototype.constructor.prototype);
console.log(Singleton.prototype.constructor.prototype);
console.log(Singleton.prototype);
console.log(Singleton.constructor);
```

results in:

```bash
constructor {
  constructor: [Function: constructor],
  add: [Function: add],
  create: [Function: create] }
Factory {
  constructor: [Function: Factory],
  destroy: [Function: destroy] }
Singleton {
  constructor: [Function: Singleton],
  destroy: [Function: destroy],
  one: 1 }
[Function: Function]
```

as expected